### PR TITLE
adding in files that should have been copied over from .github

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,84 @@
+- [Overview](#overview)
+- [Current Maintainers](#current-maintainers)
+- [Maintainer Responsibilities](#maintainer-responsibilities)
+  - [Uphold Code of Conduct](#uphold-code-of-conduct)
+  - [Prioritize Security](#prioritize-security)
+  - [Review Pull Requests](#review-pull-requests)
+  - [Triage Open Issues](#triage-open-issues)
+  - [Be Responsive](#be-responsive)
+  - [Maintain Overall Health of the Repo](#maintain-overall-health-of-the-repo)
+  - [Add Continious Integration Checks](#add-continious-integration-checks)
+    - [Developer Certificate of Origin Workflow](#developer-certificate-of-origin-workflow)
+  - [Use Semver](#use-semver)
+  - [Release Frequently](#release-frequently)
+  - [Promote Other Maintainers](#promote-other-maintainers)
+  - [Describe the Repo](#describe-the-repo)
+  
+## Overview
+
+This document explains who the maintainers are (see below), what they do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+
+## Current Maintainers
+
+| Maintainer               | GitHub ID                               | Affiliation |
+| ------------------------ | --------------------------------------- | ----------- |
+| Henri Yandell            | [hyandell](https://github.com/hyandell) | Amazon      |
+| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)     | Amazon      |
+
+## Maintainer Responsibilities
+
+Maintainers are active and visible members of the community, and have [maintain-level permissions on a repository](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization). Use those privileges to serve the community and evolve code as follows.
+
+### Uphold Code of Conduct
+
+Model the behavior set forward by the [Code of Conduct](CODE_OF_CONDUCT.md) and raise any violations to other maintainers and admins.
+
+### Prioritize Security
+
+Security is your number one priority. Maintainer's Github keys must be password protected securely and any reported security vulnerabilities are addressed before features or bugs.
+
+Note that this repository is monitored and supported 24/7 by Amazon Security, see [Reporting a Vulnerability](SECURITY.md) for details.
+
+### Review Pull Requests
+
+Review pull requests regularly, comment, suggest, reject, merge and close. Accept only high quality pull-requests. Provide code reviews and guidance on incomming pull requests. Don't let PRs be stale and do your best to be helpful to contributors.
+
+### Triage Open Issues
+
+Manage labels, review issues regularly, and triage by labelling them. 
+
+All repositories in this organization have a standard set of labels, including `bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `blocker`, `invalid`, `question`, `wontfix`, and `untriaged`, along with release labels, such as `v1.0.0`, `v1.1.0`, `v2.0.0`, `patch`, and `backport`.
+
+Use labels to target an issue or a PR for a given release, add `help wanted` to good issues for new community members, and `blocker` for issues that scare you or need immediate attention. Request for more information from a submitter if an issue is not clear. Create new labels as needed by the project.
+
+### Be Responsive
+
+Respond to enhancement requests, and forum posts. Allocate time to reviewing and commenting on issues and conversations as they come in. 
+
+### Maintain Overall Health of the Repo
+
+Keep the `main` branch at production quality at all times. Backport features as needed. Cut release branches and tags to enable future patches. 
+
+### Add Continious Integration Checks
+
+Add integration checks that validate pull requests and pushes to ease the burden on Pull Request reviewers.
+
+#### Developer Certificate of Origin Workflow
+
+Validates pull requests commits are all signed with DCO, [dco.yml](./workflow/dco.yml).  Example [pull request](https://github.com/opensearch-project/opensearch-ci/pull/16).
+
+### Use Semver
+
+Use and enforce [semantic versioning](https://semver.org/) and do not let breaking changes be made outside of major releases.
+
+### Release Frequently
+
+Make frequent project releases to the community.
+
+### Promote Other Maintainers
+
+Assist, add, and remove [MAINTAINERS](MAINTAINERS.md). Exercise good judgement, and propose high quality contributors to become co-maintainers.
+
+### Describe the Repo
+
+Make sure the repo has a well-written, accurate, and complete description. See [opensearch-project/.github#38](https://github.com/opensearch-project/.github/issues/38) for some helpful tips to describe your repo.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Description
+[Describe what this change achieves]
+ 
+### Issues Resolved
+[List any issues this PR will resolve]
+ 
+### Check List
+- [ ] Commits are signed per the DCO using --signoff 
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
+For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

--- a/README.md
+++ b/README.md
@@ -1,17 +1,36 @@
-## My Project
+![OpenSearch logo](OpenSearch.svg)
 
-TODO: Fill this README out!
+- [Welcome!](#welcome)
+- [Project Resources](#project-resources)
+- [Code of Conduct](#code-of-conduct)
+- [License](#license)
+- [Copyright](#copyright)
 
-Be sure to:
+## Welcome!
 
-* Change the title in this README
-* Edit your repository description on GitHub
+**OpenSearch** is [a community-driven, open source fork](https://aws.amazon.com/blogs/opensource/introducing-opensearch/) of [Elasticsearch](https://en.wikipedia.org/wiki/Elasticsearch) and [Kibana](https://en.wikipedia.org/wiki/Kibana) licensed under the [Apache v2.0 License](LICENSE.txt). For more information, see [opensearch.org](https://opensearch.org/).
 
-## Security
+## Project Resources
 
-See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+* [Project Website](https://opensearch.org/)
+* [Downloads](https://opensearch.org/downloads.html).
+* [Documentation](https://docs-beta.opensearch.org/)
+* Need help? Try [Forums](https://discuss.opendistrocommunity.dev/)
+* [Project Principles](https://opensearch.org/#principles)
+* [Contributing to OpenSearch](CONTRIBUTING.md)
+* [Maintainer Responsibilities](MAINTAINERS.md)
+* [Release Management](RELEASING.md)
+* [Admin Responsibilities](ADMINS.md)
+* [Security](SECURITY.md)
+
+## Code of Conduct
+
+This project has adopted the [Amazon Open Source Code of Conduct](CODE_OF_CONDUCT.md). For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq), or contact [opensource-codeofconduct@amazon.com](mailto:opensource-codeofconduct@amazon.com) with any additional questions or comments.
 
 ## License
 
-This project is licensed under the Apache-2.0 License.
+This project is licensed under the [Apache v2.0 License](LICENSE.txt).
 
+## Copyright
+
+Copyright OpenSearch Contributors. See [NOTICE](NOTICE.txt) for details.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,136 @@
+- [Overview](#overview)
+- [Branching](#branching)
+  - [OpenSearch Branching](#opensearch-branching)
+  - [Plugin Branching](#plugin-branching)
+  - [Feature Branches](#feature-branches)
+- [Versioning](#versioning)
+  - [Version Numbers](#version-numbers)
+  - [Incrementing Versions](#incrementing-versions)
+- [Tagging](#tagging)
+- [Releasing](#releasing)
+  - [Release Labels](#release-labels)
+  - [Release Schedule](#release-scheduling)
+  - [Release Schedule Date Definitions](#release-schedule-date-definitions)
+  
+- [Backporting](#backporting)
+
+## Overview
+
+This document explains the release strategy for artifacts in this organization.
+
+## Branching
+
+Projects create a new branch when they need to start working on 2 separate versions of the product, with the `main` branch being the furthermost release. 
+
+### OpenSearch Branching
+
+[OpenSearch](https://github.com/opensearch-project/OpenSearch) typically tracks 3 releases in parallel. For example, given the last major release of 1.0, OpenSearch in this organization maintains the following active branches.
+
+* **main**: The _next major_ release, currently 2.0. This is the branch where all merges take place, and code moves fast.
+* **1.x**: The _next minor_ release, currently 1.1. Once a change is merged into `main`, decide whether to backport it to `1.x`.
+* **1.0**: The _current_ release, currently 1.0. In between minor releases, only hotfixes (e.g. security) are backported to `1.0`. The next release out of this branch will be 1.0.1.
+
+Label PRs with the next major version label (e.g. `2.0.0`) and merge changes into `main`. Label PRs that you believe need to be backported as `1.x` and `1.0`. Backport PRs by checking out the versioned branch, cherry-pick changes and open a PR against each target backport branch.
+
+### Plugin Branching
+
+Plugins, such as [job-scheduler](https://github.com/opensearch-project/job-scheduler) aren't as active as OpenSearch, and typically track 2 releases in parallel instead of 3. This still translates into 3 branches. For example, given the last major release of 1.0, job-scheduler maintains the following.
+
+* **main**: The _next_ release, currently 1.1. This is the branch where all merges take place, and code moves fast.
+* **1.x**: A common parent branch for the series of 1.x releases. This is where 1.x patches will be made when `main` becomes 2.0.
+* **1.0**: The _current_ release, currently 1.0. This branch's parent is `1.x` to make future merges easier. 'In between minor releases, only hotfixes (e.g. security) are backported to `1.0`. The next release out of this branch will be 1.0.1.
+
+### Feature Branches
+
+Do not creating branches in the upstream repo, use your fork, for the exception of long lasting feature branches that require active collaboration from multiple developers. Name feature branches `feature/<thing>`. Once the work is merged to `main`, please make sure to delete the feature branch.
+
+## Versioning
+
+OpenSearch versioning [follows semver](https://opensearch.org/blog/technical-post/2021/08/what-is-semver/). 
+
+### Version Numbers
+
+The build number of the engine is 3-digit `major.minor.patch` (e.g. `1.1.0`), while plugins use 4 digits (`1.1.0.45`). See [OpenSearch#1093](https://github.com/opensearch-project/OpenSearch/issues/1093) for a proposal to remove this difference. 
+
+### Incrementing Versions
+
+Versions are incremented as soon as development starts on a given version to avoid confusion. In the examples above versions are as follows.
+
+* OpenSearch: `main` = 2.0.0, `1.x` = 1.1.0, and `1.0` = 1.0.0
+* job-scheduler: `main` = 1.1.0.0, `1.0` = 1.0.0.0
+
+## Tagging
+
+Create tags after a release that match the version number, `major.minor.patch`, without a `v` prefix.
+
+* [OpenSearch tags](https://github.com/opensearch-project/OpenSearch/tags): [1.0.0](https://github.com/opensearch-project/OpenSearch/releases/tag/1.0.0)
+* [job-scheduler tags](https://github.com/opensearch-project/job-scheduler/tags): [1.0.0.0](https://github.com/opensearch-project/job-scheduler/releases/tag/1.0.0.0)
+
+For a discussion on whether to add a prefixing `v` to release tags, see [#35](https://github.com/opensearch-project/.github/issues/35).  
+
+## Releasing
+
+### Release Labels
+
+Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v2.0.0`, as well as `patch` and `backport`. Use release labels to target an issue or a PR for a given release. See [MAINTAINERS](MAINTAINERS.md#triage-open-issues) for more information on triaging issues.
+
+## Release Scheduling
+
+Because OpenSearch currently releases as a bundle, the OpenSearch release process is centralized and has several steps along the way.  As the first step in this release process, the Engineering Effectiveness team creates a release ticket in the [opensearch-build repo](https://github.com/opensearch-project/opensearch-build) and assigns it to an overall release manager (example: [2.0 release ticket](https://github.com/opensearch-project/opensearch-build/issues/1650)).  The team also creates individual release issues per repo with what's expected to go in that release. If you have a question about a release, you can always comment on a release issue using @opensearch-project/engineering-effectiveness.  
+
+### Release Schedule Date Definitions
+
+#### Feature Freeze
+All code changes that add new capabilities to OpenSearch need to be merged to "main" and backported to the planned release. Additional merges/backports can happen for bugs fixes and CVEs.  Only major releases have a feature freeze date.
+
+#### Code Freeze
+This is date where we expect everything is working and there are no known issues. Freezing the code before the release date gives us a chance to perform long-running performance tests and do other final verifications. 
+
+No more changes can be merged to the release branch after this point except for fixes to blocking bugs. To prevent accidental changes, repository branches will no longer be added to the distribution build by default.  To make a change to the release after the code freeze date, open an issue in the opensearch-build repo with the repo the change is in, a justification for why the change is needed, and a link to the PR.  If the change is approved, the team will cut a PR to update the manifest. 
+
+All major, minor and patch releases have code freeze dates.  Code freeze generally happens 1 week before the release date for minor versions,with the freeze date being longer and shorter for major and patch releases respectively.
+
+#### Release Date
+The date artifacts are made available on opensearch.org or other sources like NPM.
+
+For 2022 we're tracking the overall release dates for OpenSearch [in the forums](https://opensearch.org/blog/partners/2022/02/roadmap-proposal/). 
+
+
+## Day of Release Activities
+Once we reach the Release Date, the following things happen:
+1. Two candidate bundle builds for OpenSearch and OpenSearch Dashboards, produced by [bundle-workflow](https://github.com/opensearch-project/opensearch-build/blob/main/bundle-workflow/README.md), are chosen as release candidates. Those artifacts have successful end-to-end integration, backwards-compatibility and performance tests, and are signed.
+2. Staged maven artifacts are promoted to Maven Central.
+3. Bundles and -min artifacts are published to [opensearch.org](https://opensearch.org/downloads.html).
+
+## Backporting
+
+This project follows [semantic versioning](https://semver.org/spec/v2.0.0.html). Backwards-incompatible changes always result in a new major version and will __never__ be backported. Small improvements and features will be backported to a new minor version (e.g. `1.1`). Security fixes will be backported to a new patch version (e.g. `1.0.1`).
+
+Here are the commands we typically run to backport changes to release branches:
+
+1. Checkout the target release branch and pull the latest changes from `upstream`. In the examples below, our target release branch is `1.x`.
+
+```
+git checkout 1.x
+git pull upstream 1.x
+```
+
+2. Create a local branch for the backport. A convenient naming convention is _backport-\[PR-id\]-\[target-release-branch\]_.
+
+```
+git checkout -b backport-pr-xyz-1.x
+```
+
+3. Cherry-pick the commit to backport. Remember to include [DCO signoff](CONTRIBUTING.md#developer-certificate-of-origin).
+
+```
+git cherry-pick <commit-id> -s
+```
+
+4. Push the local branch to your fork.
+
+```
+git push origin backport-pr-xyz-1.x
+```
+
+5. Create a pull request for the change.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+## Reporting a Vulnerability
+
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/) or directly via email to aws-security@amazon.com. Please do **not** create a public GitHub issue.


### PR DESCRIPTION
Signed-off-by: CEHENKLE <henkle@amazon.com>

### Description
Copying over files from .github that should be here.  You'll need to customize MAINTAINERS with the right names.  You may also want to customer the PULL_REQUEST_TEMPLATE.  

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
