### PR TITLE
Aligned maintainers sections with standards.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,8 @@
-## OpenSearch UX maintainers
+## Overview
+
+[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+
+## Current Maintainers
 
 | Maintainer          | GitHub ID                                    | Affiliation |
 | ------------------- | -------------------------------------------- | ----------- |
@@ -7,5 +11,3 @@
 | Ka Ming Leung       | [kamingleung](https://github.com/kamingleung)| Amazon      |
 | Shanil Patel        | [shanilpa](https://github.com/shanilpa)      | Amazon      |
 | Laura Pavlov        | [lauralexis](https://github.com/lauralexis)  | Amazon      |
-
-[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
Signed-off-by: Daniel (dB.) Doubrovkine <dblock@amazon.com>

### Description

We have some [tools](https://github.com/opensearch-project/project-tools) that [look for specific sections](https://github.com/opensearch-project/project-tools/blob/8abfdfd532e7b0a1bb5abbf54402848dd6eeff35/lib/github/repo.rb#L31) in this file. Renamed the maintainers section to match the other projects.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
