### PR TITLE
Updated MAINTAINERS.md format.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,13 +1,13 @@
 ## Overview
 
-[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
 
 ## Current Maintainers
 
-| Maintainer          | GitHub ID                                    | Affiliation |
-| ------------------- | -------------------------------------------- | ----------- |
-| Kroosh Crusius      | [KrooshalUX](https://github.com/KrooshalUX)  | Amazon      |
-| Kevin Garcia        | [kgcreative](https://github.com/kgcreative)  | Amazon      |
-| Ka Ming Leung       | [kamingleung](https://github.com/kamingleung)| Amazon      |
-| Shanil Patel        | [shanilpa](https://github.com/shanilpa)      | Amazon      |
-| Laura Pavlov        | [lauralexis](https://github.com/lauralexis)  | Amazon      |
+| Maintainer     | GitHub ID                                     | Affiliation |
+| -------------- | --------------------------------------------- | ----------- |
+| Kroosh Crusius | [KrooshalUX](https://github.com/KrooshalUX)   | Amazon      |
+| Kevin Garcia   | [kgcreative](https://github.com/kgcreative)   | Amazon      |
+| Ka Ming Leung  | [kamingleung](https://github.com/kamingleung) | Amazon      |
+| Shanil Patel   | [shanilpa](https://github.com/shanilpa)       | Amazon      |
+| Laura Pavlov   | [lauralexis](https://github.com/lauralexis)   | Amazon      |


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/.github/issues/121, updated MAINTAINERS.md to match opensearch-project recommended format.